### PR TITLE
Improve Estonian translations

### DIFF
--- a/src/assets/language/translations.json
+++ b/src/assets/language/translations.json
@@ -149,11 +149,11 @@
     "recovered": "Taastunud",
     "deaths": "Surmad",
     "death_cases": "Surmajuhtumid",
-    "footer_info": "Koroona info jagab informatsioonid COVID-19 juhtumite kohta Soomas. Andmeid uuendatakse iga 10 minuti tagant.",
+    "footer_info": "Koroona info jagab informatsiooni COVID-19 juhtumite kohta Soomes. Andmeid uuendatakse iga 10 minuti tagant.",
     "footer_finnish_data_info": "Soome andmete allikana kasutame",
     "footer_finnish_data_link_text": "Helsingin Sanomat poolt pakutud avatud andmeid",
     "footer_global_data_info": "Globaalsete andmete allikana kasutame",
-    "footer_global_data_link_text": "Andmeid pakutud John Hopkins University poolt",
+    "footer_global_data_link_text": "John Hopkins Ülikooli poolt avaldatud andmeid",
 
     "unknown": "Pole teada",
     "pcs": "tk",
@@ -163,7 +163,7 @@
     "infections_originated_from_finland": "Nakkused Soomesiseselt",
     "infections_originated_from_foreign_countries": "Nakkused välisriikidest",
     "infections_originated_from_unknown_sources": "Nakkused tundmatutest allikatest",
-    "infections_originated_from_finland_vs_other_sources": "Nakkuse pärinemine Soomesiseselt vs väliselt",
+    "infections_originated_from_finland_vs_other_sources": "Nakkuse pärinemine Soomesiseselt vs välisriikidest",
     "infection_count_cumulative": "Nakatute arv (kumulatiivne)",
     "recovered_count_cumulative": "Taastunute arv (kumulatiivne)"
   }


### PR DESCRIPTION
Some translations were worded strangely when taken in context.
Additionally, there were some typos.